### PR TITLE
17 implement oauth2 dependency get current user

### DIFF
--- a/backend/app/dependencies/auth.py
+++ b/backend/app/dependencies/auth.py
@@ -1,0 +1,68 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Annotated
+import uuid
+import os
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import OAuth2PasswordBearer
+from jose import jwt, JWTError
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from ..models.database import get_db
+from ..models.user import User
+
+SECRET_KEY = os.getenv("SECRET_KEY")
+ALGORITHM = "HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+# 1. Define OAuth2 Scheme pointing to the login endpoint
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/token")
+
+
+def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
+    to_encode = data.copy()
+    if expires_delta:
+        expire = datetime.now(timezone.utc) + expires_delta
+    else:
+        expire = datetime.now(timezone.utc) + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
+
+    to_encode.update({"exp": expire})
+    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+    return encoded_jwt
+
+
+# 2. Create reusable dependency
+async def get_current_user(
+        token: Annotated[str, Depends(oauth2_scheme)],
+        db: Annotated[AsyncSession, Depends(get_db)]
+) -> User:
+    credentials_exception = HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Could not validate credentials",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+    # 3. Decode and validate token
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=[ALGORITHM])
+        user_id: str = payload.get("sub")
+        if user_id is None:
+            raise credentials_exception
+    except JWTError:
+        raise credentials_exception
+
+    # 4. Fetch user from database
+    try:
+        # Cast user_id string to UUID for the query
+        query = select(User).where(User.id == uuid.UUID(user_id))
+        result = await db.execute(query)
+        user = result.scalar_one_or_none()
+    except (ValueError, TypeError):
+        # Handle cases where the ID in the token is not a valid UUID
+        raise credentials_exception
+
+    if user is None:
+        raise credentials_exception
+
+    return user

--- a/backend/app/routers/Users.py
+++ b/backend/app/routers/Users.py
@@ -3,10 +3,12 @@ from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
+from ..dependencies.auth import get_current_user
 from ..models.database import get_db
 from ..models.user import User
 from ..schemas.user import UserCreate, UserOut
 from ..utils import password
+from typing import Annotated
 
 router = APIRouter()
 
@@ -39,3 +41,14 @@ async def register_user(user_in: UserCreate, db: AsyncSession = Depends(get_db))
     await db.refresh(new_user)
 
     return new_user
+
+# sanity check endpoint
+@router.get("/me", response_model=UserOut)
+async def read_users_me(current_user: Annotated[User, Depends(get_current_user)]):
+    """
+    Get current user's information
+    Requires valid JWT authentication
+    :param current_user:
+    :return:
+    """
+    return current_user

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.1
 asyncpg==0.31.0
-bcrypt==5.0.0
+bcrypt==3.2.2
 click==8.3.1
 dnspython==2.8.0
 ecdsa==0.19.1


### PR DESCRIPTION
This PR implements the core security dependency get_current_user, which serves as the "gatekeeper" for protected API routes. It validates JWT tokens and resolves them to a database user.

Additionally, I added a protected sanity-check endpoint (/api/v1/me) and resolved a critical crash related to password hashing dependencies.

🛠 Key Changes
1. Security Dependency (backend/app/auth.py)
OAuth2 Scheme: Initialized OAuth2PasswordBearer pointing to the /api/v1/token endpoint.

get_current_user: Created an async dependency that:

Extracts the Bearer token from the header.

Decodes and validates the JWT (checking expiration and signature).

Extracts the sub (User ID) from the payload.

Verifies the user still exists in the database using the injected AsyncSession.

Raises a standard 401 Unauthorized error (with WWW-Authenticate headers) if any step fails.

2. Sanity Check Endpoint (backend/app/routers/Users.py)
Added GET /api/v1/me: A simple protected route that returns the authenticated user's profile.

This confirms that the Depends(get_current_user) injection is working correctly.

3. Bug Fix: Dependency Conflict (backend/requirements.txt)
Downgraded bcrypt to 3.2.2.

Why? There is a known incompatibility between passlib 1.7.4 and bcrypt 4.0+ (specifically, passlib calls an internal __about__ attribute that was removed in newer bcrypt versions), causing the application to crash during registration/login. Pinning version 3.2.2 resolves this stability issue.

🔍 How to Test
Rebuild Containers: Run ./rebuildAndRestart.sh to pick up the dependency change.

Login: Go to Swagger UI (/docs), use the Authorize button (or POST /api/v1/token) to log in with an existing user.

Verify Access:

Call GET /api/v1/me.

Success: Returns status 200 and the user JSON object.

Failure: Remove the token (logout) and call it again to verify you receive a 401 Not authenticated.