### PR TITLE
22 update resource models for family isolation

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,7 @@
 from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from .models.database import init_db
-from .routers import Users, auth, families
+from .routers import Users, auth, families, ingredients, recipes
 
 
 @asynccontextmanager
@@ -16,7 +16,9 @@ app = FastAPI(lifespan=lifespan)
 
 app.include_router(Users.router, prefix="/api/v1", tags=["users"])
 app.include_router(auth.router, prefix="/api/v1", tags=["auth"])
-app.include_router(families.router, prefix="/api/v1/families", tags=["families"]) # Add this
+app.include_router(families.router, prefix="/api/v1/families", tags=["families"])
+app.include_router(ingredients.router, prefix="/api/v1", tags=["ingredients"])
+app.include_router(recipes.router, prefix="/api/v1", tags=["recipes"])
 
 @app.get("/")
 def read_root():

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
-# app/models/__init__.py
 from .database import Base
 from .user import User
 from .family import Family
+from .ingredient import Ingredient
+from .recipy import Recipe

--- a/backend/app/models/family.py
+++ b/backend/app/models/family.py
@@ -19,6 +19,12 @@ class Family(Base):
     #relationship to access family.users
     users: Mapped[List["User"]] = relationship("User", back_populates="family")
 
+    ingredients: Mapped[List["Ingredient"]] = relationship(
+        "Ingredient", back_populates="family", cascade="all, delete-orphan"
+    )
+    recipes: Mapped[List["Recipe"]] = relationship(
+        "Recipe", back_populates="family", cascade="all, delete-orphan"
+    )
 
     def __repr__(self):
         return f"Family(id={self.id}, name={self.name})"

--- a/backend/app/models/ingredient.py
+++ b/backend/app/models/ingredient.py
@@ -1,0 +1,24 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import String, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .database import Base
+
+class Ingredient(Base):
+    __tablename__ = "ingredients"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True
+    )
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(default=datetime.utcnow, onupdate=datetime.utcnow)
+
+    family_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("families.id"), nullable=False)
+    family: Mapped["Family"] = relationship("Family", back_populates="ingredients")
+
+    def __repr__(self):
+        return f"Ingredient(id={self.id}, name={self.name}, family_id={self.family_id})"

--- a/backend/app/models/recipy.py
+++ b/backend/app/models/recipy.py
@@ -1,0 +1,21 @@
+import uuid
+from sqlalchemy import String, Text, ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+from .database import Base
+
+class Recipe(Base):
+    __tablename__ = "recipes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        primary_key=True,
+        default=uuid.uuid4,
+        index=True
+    )
+    title: Mapped[str] = mapped_column(String(150), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    family_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("families.id"), nullable=False)
+    family: Mapped["Family"] = relationship("Family", back_populates="recipes")
+
+    def __repr__(self):
+        return f"Recipe(id={self.id}, title={self.title}, family_id={self.family_id})"

--- a/backend/app/routers/ingredients.py
+++ b/backend/app/routers/ingredients.py
@@ -1,0 +1,54 @@
+from typing import List, Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from ..models.database import get_db
+from ..models.ingredient import Ingredient
+from ..models.user import User
+from ..schemas.ingredient import IngredientCreate, IngredientOut
+from ..dependencies.auth import get_current_user
+
+router = APIRouter()
+router.prefix = "/ingredients"
+router.tags = ["Ingredients"]
+
+
+@router.post("/", response_model=IngredientOut, status_code=status.HTTP_201_CREATED)
+async def create_ingredient(
+        ingredient_in: IngredientCreate,
+        current_user: Annotated[User, Depends(get_current_user)],
+        db: AsyncSession = Depends(get_db)
+):
+    if not current_user.family_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User must belong to a family to create ingredients."
+        )
+
+    new_ingredient = Ingredient(
+        **ingredient_in.model_dump(),
+        #auto fetched family id from current_user
+        family_id=current_user.family_id
+    )
+
+    db.add(new_ingredient)
+    await db.commit()
+    await db.refresh(new_ingredient)
+    return new_ingredient
+
+
+@router.get("/", response_model=List[IngredientOut])
+async def get_ingredients(
+        current_user: Annotated[User, Depends(get_current_user)],
+        db: AsyncSession = Depends(get_db)
+):
+    if not current_user.family_id:
+        return []
+
+    # Only fetch ingredients belonging to the user's family
+    query = select(Ingredient).where(Ingredient.family_id == current_user.family_id)
+    result = await db.execute(query)
+    return result.scalars().all()

--- a/backend/app/routers/recipes.py
+++ b/backend/app/routers/recipes.py
@@ -1,0 +1,52 @@
+from typing import List, Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from ..models.database import get_db
+from ..models.recipy import Recipe
+from ..models.user import User
+from ..schemas.recipe import RecipeCreate, RecipeOut
+from ..dependencies.auth import get_current_user
+
+router = APIRouter()
+router.prefix = "/recipes"
+router.tags = ["Recipes"]
+
+@router.post("/", response_model=RecipeOut, status_code=status.HTTP_201_CREATED)
+async def create_recipe(
+    recipe_in: RecipeCreate,
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db)
+):
+    if not current_user.family_id:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="User must belong to a family to create recipes."
+        )
+
+    new_recipe = Recipe(
+        **recipe_in.model_dump(),
+        # auto fetched family id from current_user
+        family_id=current_user.family_id
+    )
+
+    db.add(new_recipe)
+    await db.commit()
+    await db.refresh(new_recipe)
+    return new_recipe
+
+@router.get("/", response_model=List[RecipeOut])
+async def get_recipes(
+    current_user: Annotated[User, Depends(get_current_user)],
+    db: AsyncSession = Depends(get_db)
+):
+    if not current_user.family_id:
+        return []
+
+    # Isolation logic
+    query = select(Recipe).where(Recipe.family_id == current_user.family_id)
+    result = await db.execute(query)
+    return result.scalars().all()

--- a/backend/app/schemas/ingredient.py
+++ b/backend/app/schemas/ingredient.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, ConfigDict
+from uuid import UUID
+
+class IngredientBase(BaseModel):
+    name: str
+
+class IngredientCreate(IngredientBase):
+    pass
+
+class IngredientOut(IngredientBase):
+    id: UUID
+    family_id: UUID
+
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/app/schemas/recipe.py
+++ b/backend/app/schemas/recipe.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, ConfigDict
+from uuid import UUID
+from typing import Optional
+
+class RecipeBase(BaseModel):
+    title: str
+    description: Optional[str] = None
+
+class RecipeCreate(RecipeBase):
+    pass
+
+class RecipeOut(RecipeBase):
+    id: UUID
+    family_id: UUID
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
**Description**
This PR implements strict data isolation for Ingredients and Recipes, ensuring that these resources belong exclusively to a specific family. It updates the database models to include a mandatory family_id, updates the Pydantic schemas, and adds new API routers that enforce ownership server-side.

**Key Changes:

Database Models:**

Updated Family model to include back-populated relationships for ingredients and recipes.

Created Ingredient and Recipe models with a non-nullable ForeignKey("families.id").

**Schemas:**

Updated IngredientOut and RecipeOut to expose family_id.

Ensured Create schemas do not accept family_id manually, as it is assigned via the backend.

**API Endpoints:**

Added POST /ingredients/ and GET /ingredients/ endpoints.

Added POST /recipes/ and GET /recipes/ endpoints.

Logic: Endpoints automatically populate family_id from the authenticated current_user. Users cannot create or view resources belonging to other families.

**Configuration:**

Registered new routers in main.py.

Type of Change
[ ] Bug fix

[x] New feature

[x] Breaking change (requires database reset)

**How to Test**
Reset Database: Since family_id is non-nullable, existing data is invalid.

Bash
docker compose down -v
docker compose up --build
Register & Create Family:

Create a user and a family via /api/v1/register and /api/v1/families/.

**Test Ingredients/Recipes:**

POST /api/v1/ingredients/: Create an ingredient (verify family_id is automatically set in response).

GET /api/v1/ingredients/: Verify you see only your family's ingredients.

Isolation Check (Optional):

Create a second user/family.

Verify the second user cannot see the first user's ingredients.

Checklist
[x] Models updated with Mapped and mapped_column syntax.

[x] family_id is set to nullable=False.

[x] Routers implemented with automatic ID assignment (no manual entry).

[x] Database reset required.